### PR TITLE
fix/ajax-authorization

### DIFF
--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -9,7 +9,20 @@ Plugin uri: https://wpml.org
 Version: 0.5.0
  */
 
+defined('ABSPATH') || exit;
+
 class Migrate_Polylang_To_WPML {
+
+	/**
+	 * Nonce action shared by every AJAX endpoint of this plugin.
+	 */
+	const NONCE_ACTION = 'mpw_migrate';
+
+	/**
+	 * Capability required to run or undo a migration.
+	 */
+	const CAPABILITY = 'manage_options';
+
 	private $polylang_data;
 	private $mpw_htaccess_check;
 
@@ -45,6 +58,8 @@ class Migrate_Polylang_To_WPML {
 
 			wp_register_script('migrate-ajax',  plugins_url('scripts/ajax.js', __FILE__), array('jquery'), '', true);
 			$ajax_strings_translations = array(
+				'nonce' => wp_create_nonce(self::NONCE_ACTION),
+
 				'mig_start' => __("Migration started, please don't close this window...", 'migrate-polylang'),
 				'lan_start' => __("Moving your language settings...", 'migrate-polylang'),
 				'posts_start' => __("Setting languages for posts...", 'migrate-polylang'),
@@ -278,7 +293,42 @@ $text = "
 		return !$this->polylang_data_deleted() && $this->pre_check_polylang() and $this->pre_check_wpml() and $this->pre_check_wizard_complete();
 	}
 
+	/**
+	 * Rejects any AJAX request that isn't a deliberate action by an authorised administrator.
+	 *
+	 * Both halves matter. The capability check stops lower-privileged users from calling these
+	 * endpoints directly; the nonce stops a third-party page from driving them through a
+	 * logged-in administrator's browser.
+	 *
+	 * Sends a JSON error and terminates the request when either check fails.
+	 *
+	 * @return bool True when the request may proceed.
+	 */
+	private function verify_ajax_request() {
+		if (!current_user_can(self::CAPABILITY)) {
+			wp_send_json_error(array(
+				'msg' => __("You don't have permission to perform this action.", 'migrate-polylang'),
+				'res' => 'error'
+			), 403);
+
+			return false;
+		}
+
+		if (!check_ajax_referer(self::NONCE_ACTION, 'nonce', false)) {
+			wp_send_json_error(array(
+				'msg' => __("Security check failed. Please reload the page and try again.", 'migrate-polylang'),
+				'res' => 'error'
+			), 403);
+
+			return false;
+		}
+
+		return true;
+	}
+
 	public function ajax_migrate_languages() {
+		$this->verify_ajax_request();
+
 		if ($this->pre_check_ready_all()) {
 			$this->migrate_languages();
 			$response = array(
@@ -290,6 +340,8 @@ $text = "
 	}
 
 	public function ajax_migrate_posts() {
+		$this->verify_ajax_request();
+
 		if ($this->pre_check_ready_all()) {
 			require_once 'classes/class-mpw_migrate_posts.php';
 			$mpw_migrate_posts = new mpw_migrate_posts($this->polylang_data);
@@ -303,6 +355,8 @@ $text = "
 	}
 
 	public function ajax_migrate_taxonomies() {
+		$this->verify_ajax_request();
+
 		if ($this->pre_check_ready_all()) {
 			$this->migrate_taxonomies();
 			$response = array(
@@ -314,6 +368,8 @@ $text = "
 	}
 
 	public function ajax_migrate_strings() {
+		$this->verify_ajax_request();
+
 		if ($this->pre_check_ready_all() && $this->pre_check_wpml_st()) {
 			$this->migrate_strings();
 			$response = array(
@@ -330,6 +386,8 @@ $text = "
 	}
 
 	public function ajax_migrate_widgets() {
+		$this->verify_ajax_request();
+
 		if ($this->pre_check_ready_all() && $this->pre_check_wpml_widgets()) {
 			$this->migrate_widgets();
 			$response = array(
@@ -347,6 +405,8 @@ $text = "
 	}
 
 	public function ajax_delete_polylang_data() {
+		$this->verify_ajax_request();
+
 		$this->polylang_data->delete_data();
 		$response = array(
 			'msg' => __("Polylang data removed from database", 'migrate-polylang'),

--- a/scripts/ajax.js
+++ b/scripts/ajax.js
@@ -6,23 +6,23 @@ jQuery(document).ready(function( $ ) {
 		
 		$('#mpw_ajax_result').empty().append("<div>"+mpw_ajax_str.mig_start+"</div>");
 		$('#mpw_ajax_result').append("<div>"+mpw_ajax_str.lan_start+"</div>");
-		$.post(ajaxurl,{'action':'mpw_migrate_languages'})
+		$.post(ajaxurl,{'action':'mpw_migrate_languages','nonce':mpw_ajax_str.nonce})
 				.done(function(resp){ 
 					$('#mpw_ajax_result').append("<div>"+resp.data.msg+"</div>");
 					$('#mpw_ajax_result').append("<div>"+mpw_ajax_str.posts_start+"</div>");
-					$.post(ajaxurl,{'action':'mpw_migrate_posts'})
+					$.post(ajaxurl,{'action':'mpw_migrate_posts','nonce':mpw_ajax_str.nonce})
 							.done(function(resp) {
 								$('#mpw_ajax_result').append("<div>"+resp.data.msg+"</div>");
 								$('#mpw_ajax_result').append("<div>"+mpw_ajax_str.tax_start+"</div>");
-								$.post(ajaxurl,{'action':'mpw_migrate_taxonomies'})
+								$.post(ajaxurl,{'action':'mpw_migrate_taxonomies','nonce':mpw_ajax_str.nonce})
 										.done(function(resp) {
 											$('#mpw_ajax_result').append("<div>"+resp.data.msg+"</div>");
 											$('#mpw_ajax_result').append("<div>"+mpw_ajax_str.str_start+"</div>");
-											$.post(ajaxurl,{'action':'mpw_migrate_strings'})
+											$.post(ajaxurl,{'action':'mpw_migrate_strings','nonce':mpw_ajax_str.nonce})
 													.done(function(resp) {
 														$('#mpw_ajax_result').append("<div>"+resp.data.msg+"</div>");
 														$('#mpw_ajax_result').append("<div>"+mpw_ajax_str.widg_start+"</div>");
-														$.post(ajaxurl,{'action':'mpw_migrate_widgets'})
+														$.post(ajaxurl,{'action':'mpw_migrate_widgets','nonce':mpw_ajax_str.nonce})
 																.done(function(resp) {
 																	$('#mpw_ajax_result').append("<div>"+resp.data.msg+"</div>");
 																	$('#mpw_ajax_result').append("<div><strong>"+mpw_ajax_str.mig_done+"</strong></div>");
@@ -44,7 +44,7 @@ jQuery(document).ready(function( $ ) {
 			
 			$('#remove_polylang_data_result').empty().append("<div>"+mpw_ajax_str.del_start+"</div>");
 			
-			$.post(ajaxurl,{'action':'mpw_delete_polylang_data'})
+			$.post(ajaxurl,{'action':'mpw_delete_polylang_data','nonce':mpw_ajax_str.nonce})
 				.done(function(resp){
 					$('#remove_polylang_data_result').append("<div>"+resp.data.msg+"</div>");
 					$('#remove_polylang_data_part').hide();


### PR DESCRIPTION
**Summary.** Adds a capability and nonce guard to all six AJAX endpoints, closing a privilege-escalation and CSRF hole that let any logged-in user permanently erase all Polylang data.

**Problem.** All six `wp_ajax_mpw_*` actions were registered with no `current_user_can()` and no
nonce. `wp_ajax_*` fires for *any* logged-in user, so a subscriber could POST `action=mpw_delete_polylang_data` to `admin-ajax.php` and permanently erase every Polylang language, translation group and string translation — the handler documents that there is no undo. The five migration endpoints were equally open, and with no nonce any external page could drive them through a logged-in administrator's browser (CSRF).

**Change.** One `verify_ajax_request()` guard — `manage_options`, then `check_ajax_referer('mpw_migrate', 'nonce', false)` — is called first in all six handlers; either failure sends a JSON error with HTTP 403 and stops. The nonce is created with `wp_create_nonce()`, shipped through the existing `wp_localize_script()` payload, and sent back by `scripts/ajax.js` on every request. Capability and nonce action are hoisted to `self::CAPABILITY` / `self::NONCE_ACTION`.

**Risk.** Low; failures are visible. A page left open past the nonce lifetime (12–24 h) now fails with "Security check failed, reload" instead of running — correct, but a new way to stop. Any external tooling that called these actions without a nonce stops working (they are internal to the plugin's own page, theoretically).

**Verified.** `php -l` on all four PHP files (8.4). **Exercised against a live `admin-ajax.php`** on the real WordPress 7.0.2 + WPML install: a valid nonce returns 200 and runs the step; a **bad nonce and a missing nonce each return HTTP 403** with "Security check failed". A logged-out request gets no handler at all (the actions are `wp_ajax_` only, not `nopriv`). The manage_options gate is enforced by `verify_ajax_request()` and `add_submenu_page()`.