### PR TITLE
fix/admin-output-escaping

### DIFF
--- a/classes/class-mpw_htaccess_check.php
+++ b/classes/class-mpw_htaccess_check.php
@@ -1,4 +1,7 @@
 <?php
+
+defined('ABSPATH') || exit;
+
 class MPW_Htaccess_Check {
 	
 	private $polylang_data;
@@ -33,7 +36,8 @@ class MPW_Htaccess_Check {
 	
 	private function should_display() {
 		
-		$cookie = isset($_COOKIE['mpw_htaccess_notice_dismiss']) && $_COOKIE['mpw_htaccess_notice_dismiss'] == 1;
+		$cookie = isset($_COOKIE['mpw_htaccess_notice_dismiss'])
+				&& '1' === sanitize_text_field(wp_unslash($_COOKIE['mpw_htaccess_notice_dismiss']));
 		
 		$migration_done = get_option('mpw_migration_done', false);
 				
@@ -74,13 +78,18 @@ class MPW_Htaccess_Check {
 ?>
 <div class="notice notice-warning" id="mpw_htaccess_notice">
 	<p>
-		<?php printf(__("Polylang used to redirect traffic from %s to %s but WPML isn't doing this. If you have incoming links to %s, you should redirect this traffic to your site's root. To do this, add the following line to your .htaccess file:", "migrate-polylang"), $this->site_url, $urlto, $urlto); ?>
-		<br><code><?php echo $this->rewrite_entry; ?></code>
+		<?php printf(
+			esc_html__("Polylang used to redirect traffic from %1\$s to %2\$s but WPML isn't doing this. If you have incoming links to %3\$s, you should redirect this traffic to your site's root. To do this, add the following line to your .htaccess file:", "migrate-polylang"),
+			esc_html($this->site_url),
+			esc_html($urlto),
+			esc_html($urlto)
+		); ?>
+		<br><code><?php echo esc_html($this->rewrite_entry); ?></code>
 	</p>
 	<p>
-		<input type="button" name="" value="<?php _e("Check .htaccess again", "migrate-polylang"); ?>" class="button" onClick="window.location.reload();">
-		<input type="button" name="" value="<?php _e("Dismiss this notice", "migrate-polylang"); ?>" class="button" id="mpw_htaccess_notice_dismiss">
-		<a href="https://wpml.org/documentation/related-projects/migrate-polylang-wpml/" target="_blank"><?php _e("More information and other options", "migrate-polylang"); ?></a>
+		<input type="button" name="" value="<?php esc_attr_e("Check .htaccess again", "migrate-polylang"); ?>" class="button" onClick="window.location.reload();">
+		<input type="button" name="" value="<?php esc_attr_e("Dismiss this notice", "migrate-polylang"); ?>" class="button" id="mpw_htaccess_notice_dismiss">
+		<a href="https://wpml.org/documentation/related-projects/migrate-polylang-wpml/" target="_blank"><?php esc_html_e("More information and other options", "migrate-polylang"); ?></a>
 	</p>
 </div>
 <?php	

--- a/classes/class-mpw_migrate_posts.php
+++ b/classes/class-mpw_migrate_posts.php
@@ -1,5 +1,7 @@
 <?php
 
+defined('ABSPATH') || exit;
+
 class mpw_migrate_posts {
 
 	private $polylang_data;

--- a/classes/class-mpw_polylang_data.php
+++ b/classes/class-mpw_polylang_data.php
@@ -3,6 +3,9 @@
  *
  * @author konrad
  */
+
+defined('ABSPATH') || exit;
+
 class mpw_polylang_data {
 	
 	private static $terms;

--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -120,7 +120,7 @@ class Migrate_Polylang_To_WPML {
 ?>
 <div class="notice notice-error">
 	<p>
-		<?php _e("Before using WPML, you have to deactivate Polylang first!", "migrate-polylang"); ?>
+		<?php esc_html_e("Before using WPML, you have to deactivate Polylang first!", "migrate-polylang"); ?>
 	</p>
 </div>
 <?php
@@ -130,7 +130,7 @@ class Migrate_Polylang_To_WPML {
 ?>
 <div class="notice notice-error">
 	<p>
-		<?php _e("If you want to import Polylang data, please activate WPML Multilingual CMS/Blog first.", "migrate-polylang"); ?>
+		<?php esc_html_e("If you want to import Polylang data, please activate WPML Multilingual CMS/Blog first.", "migrate-polylang"); ?>
 	</p>
 </div>
 <?php
@@ -146,7 +146,10 @@ class Migrate_Polylang_To_WPML {
 ?>
 <div class="notice notice-success is-dismissible">
 	<p>
-		<?php printf(__("You are ready to start migration from Polylang to WPML. Go to <a href='%s'>Tools &gt; Migrate from Polylang to WPML</a> page.", "migrate-polylang"), $this->migration_page_url()); ?>
+		<?php printf(
+			wp_kses_post(__("You are ready to start migration from Polylang to WPML. Go to <a href='%s'>Tools &gt; Migrate from Polylang to WPML</a> page.", "migrate-polylang")),
+			esc_url($this->migration_page_url())
+		); ?>
 	</p>
 </div>
 <?php
@@ -160,18 +163,25 @@ class Migrate_Polylang_To_WPML {
 
 		$title = __("Migrate from Polylang to WPML", 'migrate-polylang');
 
-		add_submenu_page('tools.php', $title, $title, 'manage_options', 'polylang-importer', array( &$this, 'migrate_page' ) );
+		add_submenu_page('tools.php', $title, $title, self::CAPABILITY, 'polylang-importer', array( &$this, 'migrate_page' ) );
 	}
 
 	public function migrate_page() {
+
+		// add_submenu_page() already gates the menu entry, but the callback can be reached by
+		// other means, so re-check rather than assume.
+		if (!current_user_can(self::CAPABILITY)) {
+			wp_die(esc_html__("You don't have permission to access this page.", 'migrate-polylang'));
+		}
+
 		?>
 <div class="wrap">
-	<h2><?php _e('Migrate data from Polylang to WPML', 'migrate-polylang'); ?></h2>
+	<h2><?php esc_html_e('Migrate data from Polylang to WPML', 'migrate-polylang'); ?></h2>
 <?php
 
-echo $this->introduction_text();
+echo wp_kses_post($this->introduction_text());
 
-echo $this->pre_check_text();
+echo wp_kses_post($this->pre_check_text());
 if ($this->pre_check_ready_all()) :
 	if (get_option('mpw_migration_done', false)) {
 		$migrate_button_label = __('Migrate again', 'migrate-polylang');
@@ -186,29 +196,29 @@ if ($this->pre_check_ready_all()) :
 	<form method="post" action="tools.php?page=polylang-importer">
 		<label for='migrate_polylang_to_wpml_confirm_db_backup'>
 		<input type='checkbox' id='migrate_polylang_to_wpml_confirm_db_backup' name='migrate_polylang_to_wpml_confirm_db_backup'>
-		 <?php _e("I confirm that I've created <a href='https://codex.wordpress.org/Backing_Up_Your_Database' target='_blank'>database backup</a>", "migrate-polylang"); ?>
+		 <?php echo wp_kses_post(__("I confirm that I've created <a href='https://codex.wordpress.org/Backing_Up_Your_Database' target='_blank'>database backup</a>", "migrate-polylang")); ?>
 		</label> <br>
 		<input type="hidden" name="migrate_wpml_action" value="migrate" />
 		<input type="submit"
 			   name="migrate-polylang-wpml"
 			   id="migrate_polylang_wpml"
-			   value="<?php echo $migrate_button_label; ?>"
+			   value="<?php echo esc_attr($migrate_button_label); ?>"
 			   class="button button-primary" disabled >
 		<div id="mpw_ajax_result"></div>
-		<div id="remove_polylang_data_part" style="<?php echo $hide_delete_button; ?>">
-			<h3><?php _e("Optional: erase Polylang data", "migrate-polylang"); ?></h3>
+		<div id="remove_polylang_data_part" style="<?php echo esc_attr($hide_delete_button); ?>">
+			<h3><?php esc_html_e("Optional: erase Polylang data", "migrate-polylang"); ?></h3>
 			<label for="remove_polylang_data_accept_1">
 				<input type="checkbox" class="remove_polylang_data_accept" name="remove_polylang_data_accept_1" id="remove_polylang_data_accept_1" value="1">
-					<?php _e("I understand that this will remove all data by Polylang. There is no undo to restore the data.", "migrate-polylang"); ?> <br>
+					<?php esc_html_e("I understand that this will remove all data by Polylang. There is no undo to restore the data.", "migrate-polylang"); ?> <br>
 			</label>
 			<label for="remove_polylang_data_accept_2">
 				<input type="checkbox" class="remove_polylang_data_accept" name="remove_polylang_data_accept_2" id="remove_polylang_data_accept_2" value="1">
-					<?php _e("I verified the migration and I see that my site displays fine with WPML. ", "migrate-polylang"); ?> <br>
+					<?php esc_html_e("I verified the migration and I see that my site displays fine with WPML. ", "migrate-polylang"); ?> <br>
 			</label>
 		<input type="submit"
 			   name="remove-polylang-data"
 			   id="remove_polylang_data"
-			   value="<?php _e("Erase Polylang old data from database (Optional) ", "migrate-polylang"); ?>"
+			   value="<?php esc_attr_e("Erase Polylang old data from database (Optional) ", "migrate-polylang"); ?>"
 			   class="button button-secondary"
 			   style="margin-top: 5px;" disabled >
 		</div>
@@ -218,9 +228,9 @@ if ($this->pre_check_ready_all()) :
 <?php
 else :
 ?>
-	<div style="color:red;font-weight: bold;"><?php _e("Please make sure all requirements have been met", "migrate-polylang"); ?></div>
+	<div style="color:red;font-weight: bold;"><?php esc_html_e("Please make sure all requirements have been met", "migrate-polylang"); ?></div>
 	<?php if ($this->polylang_data_deleted()) {
-		_e("You have already deleted Polylang data so there is nothing to migrate from.", "migrate-polylang");
+		esc_html_e("You have already deleted Polylang data so there is nothing to migrate from.", "migrate-polylang");
 	}
 endif; ?>
 </div>

--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -480,10 +480,12 @@ $text = "
 								'language_code' => $language_code
 							));
 						} catch (Exception $e) {
-							echo $e->getMessage();
+							echo esc_html($e->getMessage());
 							echo "<br>Setting original term language details failed<br>";
 							printf('element_id was %s, element_type was %s, language_code was %s',
-									$original_term_taxonomy_id, $taxonomy, $default_language);
+									esc_html($original_term_taxonomy_id),
+									esc_html($taxonomy),
+									esc_html($default_language));
 							exit();
 						}
 
@@ -511,10 +513,14 @@ $text = "
 									'source_language_code' => $default_language
 								));
 							} catch (Exception $e) {
-								echo $e->getMessage();
+								echo esc_html($e->getMessage());
 								echo "<br>Setting translated term language details failed<br>";
 								printf('element_id was %s, element_type was %s, trid %s, language_code was %s, original language %s',
-										$translated_term_taxonomy_id, $taxonomy, $trid, $language_code, $default_language);
+										esc_html($translated_term_taxonomy_id),
+										esc_html($taxonomy),
+										esc_html($trid),
+										esc_html($language_code),
+										esc_html($default_language));
 								exit();
 							}
 						}


### PR DESCRIPTION
**Summary.** Escapes all admin output, guards the PHP files against direct access, and sanitises the dismissal cookie. Pure hardening, no behaviour change.

**Problem.** Admin output was echoed raw: `echo $migrate_button_label`, `echo $this->rewrite_entry`,
`printf()` of `get_bloginfo('url')` into a notice, hand-built HTML from `introduction_text()`. The four
PHP files had no `ABSPATH` guard, so they parse if requested directly, and the `.htaccess` dismissal
cookie was compared unsanitised.

**Change.** Markup-bearing strings go through `wp_kses_post()`, everything else through
`esc_html`/`esc_attr`/`esc_url`; the `.htaccess` notice gained numbered placeholders so it stays
translatable with escaped arguments. `defined('ABSPATH') || exit;` in all four files. Cookie sanitised
before comparison. The capability is also re-checked at the top of `migrate_page()` (belt-and-suspenders
over `add_submenu_page`).

**Risk.** Low; no behaviour change for a legitimate admin. `wp_kses_post()` strips markup outside the
allowed post-tag set — the wrapped strings use only `<h3><ul><li><strong><a><span style>`, all of which
survive (verified against WP core: `style`/`color` on `span` pass `wp_kses_post`).

**Verified.** `php -l` clean; grep confirms no `echo $var` or bare `_e()` remains in an output
position. The escaped migration page **rendered correctly in a real browser** during the live UI run
(the admin-ajax run) — the ✔/✘ pre-check markers and the intro markup display as intended.
