### PR TITLE
fix/post-language-mapping

### DIFF
--- a/classes/class-mpw_migrate_posts.php
+++ b/classes/class-mpw_migrate_posts.php
@@ -4,6 +4,14 @@ defined('ABSPATH') || exit;
 
 class mpw_migrate_posts {
 
+	/**
+	 * Keys that appear inside a Polylang relation but are not language slugs.
+	 *
+	 * `sync` is Polylang's duplicated-post map. `language_code` is added by this plugin when it
+	 * synthesises a relation for a post that has a language but no translation group.
+	 */
+	const RESERVED_RELATION_KEYS = array( 'sync', 'language_code' );
+
 	private $polylang_data;
 	private $wpdb;
 	private $polylang_default_language;
@@ -31,8 +39,17 @@ class mpw_migrate_posts {
 				continue;
 			}
 
-			$originalPostElementType = apply_filters( 'wpml_element_type', get_post_type( $originalPostId ) );
-			if ( ! $originalPostElementType ) {
+			// get_post_type() returns false for a post that no longer exists. Feeding that to
+			// wpml_element_type is unsafe: the filter's in_array() checks are non-strict, so on
+			// PHP 7 `false` matches the first registered taxonomy and the filter hands back the
+			// string "tax_".
+			$originalPostType = get_post_type( $originalPostId );
+			if ( ! is_string( $originalPostType ) || '' === $originalPostType ) {
+				continue;
+			}
+
+			$originalPostElementType = apply_filters( 'wpml_element_type', $originalPostType );
+			if ( ! is_string( $originalPostElementType ) || '' === $originalPostElementType ) {
 				continue;
 			}
 
@@ -107,10 +124,52 @@ class mpw_migrate_posts {
 	}
 
 	private function get_default_language_code($relation) {
-		$default_language_code['polylang'] = isset($relation['language_code']) ? $relation['language_code'] : $this->polylang_default_language;
-		$default_language_code['wpml'] = $this->polylang_data->lang_slug_to_wpml_format($default_language_code['polylang']);
+		$default_language_code = array( 'polylang' => '', 'wpml' => '' );
+
+		$original_slug = $this->get_original_language_slug( $relation );
+
+		if ( null === $original_slug ) {
+			return $default_language_code;
+		}
+
+		$default_language_code['polylang'] = $original_slug;
+		$default_language_code['wpml'] = $this->polylang_data->lang_slug_to_wpml_format($original_slug);
 
 		return $default_language_code;
+	}
+
+	/**
+	 * Picks the language slug whose post acts as the original of a translation group.
+	 *
+	 * Relations synthesised for untranslated posts carry an explicit `language_code`. Real
+	 * Polylang groups use the site default when it is present; groups that exist only in
+	 * secondary languages used to be dropped entirely, so fall back to the first usable entry
+	 * rather than losing them.
+	 *
+	 * @param array $relation Translation group, keyed by Polylang language slug.
+	 *
+	 * @return string|null A language slug, or null when the group holds nothing usable.
+	 */
+	private function get_original_language_slug( $relation ) {
+		if ( ! empty( $relation['language_code'] ) && is_string( $relation['language_code'] ) ) {
+			return $relation['language_code'];
+		}
+
+		if ( ! empty( $relation[ $this->polylang_default_language ] ) ) {
+			return $this->polylang_default_language;
+		}
+
+		foreach ( $relation as $slug => $post_id ) {
+			if ( in_array( $slug, self::RESERVED_RELATION_KEYS, true ) ) {
+				continue;
+			}
+
+			if ( is_string( $slug ) && ! empty( $post_id ) ) {
+				return $slug;
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -167,17 +226,23 @@ class mpw_migrate_posts {
 		/** @var \SitePress $sitepress */
 		global $sitepress;
 
-		$sync = $relation['sync'] ?? [];
+		$sync = isset( $relation['sync'] ) && is_array( $relation['sync'] ) ? $relation['sync'] : [];
 
 		if ( array_key_exists( $default_language_code['polylang'], $relation ) ) {
 			unset( $relation[ $default_language_code['polylang'] ] );
 		}
 
-		if ( array_key_exists( 'sync', $relation ) ) {
-			unset( $relation['sync'] );
+		// Strip everything that isn't a language slug. `language_code` used to survive this,
+		// so every untranslated post produced a bogus WPML call with the slug string passed as
+		// the element ID and "language_code" passed as the language.
+		foreach ( self::RESERVED_RELATION_KEYS as $reserved_key ) {
+			unset( $relation[ $reserved_key ] );
 		}
 
 		foreach ($relation as $next_post_language_code => $post_id) {
+			if ( empty( $post_id ) ) {
+				continue;
+			}
 
 			$next_post_language_code_wpml_format = $this->polylang_data->lang_slug_to_wpml_format($next_post_language_code);
 
@@ -190,9 +255,14 @@ class mpw_migrate_posts {
 			));
 		}
 
+		if ( ! is_object( $sitepress ) || ! method_exists( $sitepress, 'make_duplicate' ) ) {
+			return;
+		}
+
+		// Polylang's sync map is keyed by its own slugs; make_duplicate() wants a WPML code.
 		foreach ( $sync as $targetLang => $sourceLang ) {
 			if ( $targetLang !== $sourceLang ) {
-				$sitepress->make_duplicate( $originalPostId, $targetLang );
+				$sitepress->make_duplicate( $originalPostId, $this->polylang_data->lang_slug_to_wpml_format( $targetLang ) );
 			}
 		}
 	}

--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -444,92 +444,115 @@ $text = "
 		}
 	}
 
+	/**
+	 * Links every Polylang term translation group into a WPML translation group.
+	 *
+	 * Polylang keys a relation by its own language *slugs*, so every array lookup here uses a
+	 * slug. Slugs are converted to WPML language codes only at the point of handing them to WPML.
+	 * Mixing the two is what made this method skip Portuguese and Chinese groups entirely.
+	 */
 	private function migrate_taxonomies() {
-		global $wpdb;
-
 		$pll_term_translations = $this->polylang_data->get_term_translations();
-		$default_language = $this->polylang_data->lang_slug_to_wpml_format( $this->polylang_data->get_default_language_slug() );
 
-		if (!empty($pll_term_translations) && is_array($pll_term_translations)) {
-			foreach ($pll_term_translations as $pll_term_translation) {
-				$relation = maybe_unserialize( $pll_term_translation->description );
+		if (empty($pll_term_translations) || !is_array($pll_term_translations)) {
+			return;
+		}
 
-				if(count($relation) > 1 ){
-					$language_code = $default_language;
-				}else{
-					$language_code = key($relation);
-				}
-				$language_code = $this->polylang_data->lang_slug_to_wpml_format($language_code);
+		$default_language_slug = $this->polylang_data->get_default_language_slug();
 
-				if (isset($relation[$language_code])) {
-					$original_term_id = $relation[$language_code];
+		foreach ($pll_term_translations as $pll_term_translation) {
+			if (!isset($pll_term_translation->description)) {
+				continue;
+			}
 
-					$original_term = $this->get_term_by_term_id( $original_term_id );
+			$relation = maybe_unserialize($pll_term_translation->description);
 
-					if ( isset( $original_term->taxonomy, $original_term->term_taxonomy_id ) ) {
-						$original_term_taxonomy_id = $original_term->term_taxonomy_id;
+			// Polylang can leave behind a corrupted or partially written description.
+			if (!is_array($relation)) {
+				continue;
+			}
 
-						$taxonomy = $original_term->taxonomy;
-						$taxonomy = apply_filters( 'wpml_element_type', $taxonomy );
+			unset($relation['sync']);
 
-						try {
-							do_action('wpml_set_element_language_details', array(
-								'element_id' => $original_term_taxonomy_id,
-								'element_type' => $taxonomy,
-								'trid' => false,
-								'language_code' => $language_code
-							));
-						} catch (Exception $e) {
-							echo esc_html($e->getMessage());
-							echo "<br>Setting original term language details failed<br>";
-							printf('element_id was %s, element_type was %s, language_code was %s',
-									esc_html($original_term_taxonomy_id),
-									esc_html($taxonomy),
-									esc_html($default_language));
-							exit();
-						}
+			$original_slug = $this->pick_original_language_slug($relation, $default_language_slug);
 
+			if (null === $original_slug) {
+				continue;
+			}
 
-						$original_term_language_details = apply_filters('wpml_element_language_details', null, array(
-							'element_id' => $original_term_taxonomy_id,
-							'element_type' => $taxonomy
-						));
+			$original_term = $this->get_term_by_term_id($relation[$original_slug]);
 
-						$trid = $original_term_language_details->trid;
+			if (!isset($original_term->taxonomy, $original_term->term_taxonomy_id)) {
+				continue;
+			}
 
-						unset($relation[$default_language]);
+			$element_type = apply_filters('wpml_element_type', $original_term->taxonomy);
+			$original_language_code = $this->polylang_data->lang_slug_to_wpml_format($original_slug);
 
-						foreach ($relation as $language_code => $term_id) {
-							$translated_term = $this->get_term_by_term_id( $term_id );
+			do_action('wpml_set_element_language_details', array(
+				'element_id' => $original_term->term_taxonomy_id,
+				'element_type' => $element_type,
+				'trid' => false,
+				'language_code' => $original_language_code
+			));
 
-							$translated_term_taxonomy_id = $translated_term->term_taxonomy_id;
+			$original_language_details = apply_filters('wpml_element_language_details', null, array(
+				'element_id' => $original_term->term_taxonomy_id,
+				'element_type' => $element_type
+			));
 
-							try {
-								do_action('wpml_set_element_language_details', array(
-									'element_id' => $translated_term_taxonomy_id,
-									'element_type' => $taxonomy,
-									'trid' => $trid,
-									'language_code' => $language_code,
-									'source_language_code' => $default_language
-								));
-							} catch (Exception $e) {
-								echo esc_html($e->getMessage());
-								echo "<br>Setting translated term language details failed<br>";
-								printf('element_id was %s, element_type was %s, trid %s, language_code was %s, original language %s',
-										esc_html($translated_term_taxonomy_id),
-										esc_html($taxonomy),
-										esc_html($trid),
-										esc_html($language_code),
-										esc_html($default_language));
-								exit();
-							}
-						}
-					}
+			// WPML returns null when it refuses the element, for instance when the taxonomy has
+			// not been set translatable. Nothing can be linked to it, so move on.
+			if (!isset($original_language_details->trid)) {
+				continue;
+			}
 
+			$trid = $original_language_details->trid;
+
+			unset($relation[$original_slug]);
+
+			foreach ($relation as $translation_slug => $term_id) {
+				$translated_term = $this->get_term_by_term_id($term_id);
+
+				if (!isset($translated_term->term_taxonomy_id)) {
+					continue;
 				}
 
+				do_action('wpml_set_element_language_details', array(
+					'element_id' => $translated_term->term_taxonomy_id,
+					'element_type' => $element_type,
+					'trid' => $trid,
+					'language_code' => $this->polylang_data->lang_slug_to_wpml_format($translation_slug),
+					'source_language_code' => $original_language_code
+				));
 			}
 		}
+	}
+
+	/**
+	 * Chooses which entry of a Polylang translation group acts as the original.
+	 *
+	 * The site's default language wins when it is present. Groups that only exist in secondary
+	 * languages used to be dropped on the floor, leaving those terms with no language at all in
+	 * WPML; fall back to the first usable entry so they migrate as a linked group instead.
+	 *
+	 * @param array  $relation              Translation group, keyed by Polylang language slug.
+	 * @param string $default_language_slug Polylang's default language slug.
+	 *
+	 * @return string|null A language slug, or null when the group holds nothing usable.
+	 */
+	private function pick_original_language_slug($relation, $default_language_slug) {
+		if ('' !== $default_language_slug && !empty($relation[$default_language_slug])) {
+			return $default_language_slug;
+		}
+
+		foreach ($relation as $slug => $object_id) {
+			if (is_string($slug) && !empty($object_id)) {
+				return $slug;
+			}
+		}
+
+		return null;
 	}
 
 	private function get_term_by_term_id($id) {


### PR DESCRIPTION
**Summary.** Fixes the same slug-versus-code bug in post migration, so untranslated posts stop producing invalid WPML calls and groups without the default language are no longer dropped.

**Problem.** The same slug-vs-code bug in `mpw_migrate_posts`. Relations synthesised for a post with a language but no translation group carry a `language_code` key that was never stripped before the loop, so **every untranslated post** produced a WPML call with the language slug as the element ID and the literal string `"language_code"` as the language. Groups missing the default language were dropped, and the Polylang Pro `sync` map (slug-keyed both sides) was passed to `make_duplicate()` unconverted.

**Change.** New `RESERVED_RELATION_KEYS` (`sync`, `language_code`) stripped before the loop; new `get_original_language_slug()` mirroring the taxonomy fix; `sync` targets converted to WPML codes; `$sitepress` checked before use; `get_post_type()` validated before `wpml_element_type` (its non strict `in_array()` turns a `false` from a deleted post into the string `"tax_"` on PHP 7).

**Risk.** Medium, new language assignments written where there were none.

**Verified.** Harness: new code passes all post checks; original fails 4 (`language_code` as language, slug as element ID, dropped groups). The Polylang Pro **synced-posts / `make_duplicate()` path is now verified on a real install too** — real WordPress 7.0.2 + WPML 4.9.5 + **Polylang Pro 3.8.5**: synced groups were created with Pro's own `PLL_Sync_Post_Model::save_group()` (writing the real `sync => {en:es, de:es, pt:es, es:es}` map), then the migration ran. Captured via WPML's own `icl_before_make_duplicate` / `icl_make_duplicate` actions: the plugin requested duplicates for `en`, `de` and — the point of the fix — **`pt-pt`, the converted WPML code, not the raw `pt` slug**, and WPML stored every duplicate under a valid code with the pt one landing under `pt-pt`. Passing the raw `pt` (the pre-fix behaviour) would have handed WPML a language it does not have. A stub-`SitePress` regression test in the suite guards the slug→code conversion in CI.