### PR TITLE
Ignore orphaned Polylang taxonomy translation groups

### DIFF
--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -464,6 +464,11 @@ $text = "
 		$default_language_slug = $this->polylang_data->get_default_language_slug();
 
 		foreach ($pll_term_translations as $pll_term_translation) {
+			// Polylang can leave stale translation groups behind after terms are relinked.
+			if (empty($pll_term_translation->count)) {
+				continue;
+			}
+
 			if (!isset($pll_term_translation->description)) {
 				continue;
 			}


### PR DESCRIPTION
## Problem

Polylang can leave orphaned  entries after taxonomy terms are relinked. Although these entries no longer have any relationships, the migration still processes their serialized descriptions.

When an orphaned group is processed after a valid multilingual group, it can overwrite the correct WPML language and translation relationship.

## Solution

Skip Polylang taxonomy translation groups whose relationship count is zero.

Legitimate groups, including groups containing a single term, remain unaffected.