### PR TITLE
fix/string-translation-storage

### DIFF
--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -23,6 +23,12 @@ class Migrate_Polylang_To_WPML {
 	 */
 	const CAPABILITY = 'manage_options';
 
+	/**
+	 * Meta key Polylang stores its string translations under, on the `language` term since
+	 * Polylang 3.4 and on the polylang_mo post from 2.1 to 3.3.
+	 */
+	const PLL_STRINGS_META_KEY = '_pll_strings_translations';
+
 	private $polylang_data;
 	private $mpw_htaccess_check;
 
@@ -622,68 +628,167 @@ $text = "
 
 	}
 
+	/**
+	 * Collects Polylang's string translations for every language.
+	 *
+	 * Polylang has moved this data twice and neither move was picked up here, so the plugin has
+	 * been reading a post_content that Polylang stopped writing in 2017:
+	 *
+	 *   >= 3.4    term meta `_pll_strings_translations` on the `language` term
+	 *   2.1 - 3.3 post meta `_pll_strings_translations` on the polylang_mo post
+	 *   < 2.1     serialised array in the polylang_mo post's post_content
+	 *
+	 * Polylang deliberately leaves the older copies behind when it upgrades, so that users can
+	 * roll back. Read newest first and stop at the first location that holds anything.
+	 *
+	 * @param array $polylang_languages_map language term_id => language slug
+	 *
+	 * @return array language term_id => list of array($source, $translation)
+	 */
 	private function get_polylang_strings_array($polylang_languages_map) {
-		global $wpdb;
+		$polylang_strings_array = array();
 
-		$polylang_strings_array = null;
+		foreach (array_keys($polylang_languages_map) as $lang_id) {
+			$strings = $this->get_polylang_language_strings($lang_id);
 
-		foreach(array_keys($polylang_languages_map) as $lang_id) {
-			$post_with_polylang_strings = "SELECT post_content FROM ".$wpdb->prefix."posts where post_type = 'polylang_mo'  AND post_title=%s order by ID desc limit 1";
-
-			$polylang_strings = $wpdb->get_var($wpdb->prepare($post_with_polylang_strings, "polylang_mo_".$lang_id));
-
-
-			if ($polylang_strings) {
-				$polylang_strings_array[$lang_id] = maybe_unserialize($polylang_strings);
+			if ($strings) {
+				$polylang_strings_array[$lang_id] = $strings;
 			}
 		}
-
-
 
 		return $polylang_strings_array;
 	}
 
+	/**
+	 * @param int $lang_id A `language` taxonomy term ID.
+	 *
+	 * @return array List of array($source, $translation); empty when nothing is stored.
+	 */
+	private function get_polylang_language_strings($lang_id) {
+
+		// Polylang >= 3.4 stores the strings in the language term's meta. If that key exists at all
+		// it is authoritative — even when it holds nothing — so we must not fall through to the older
+		// copies Polylang leaves in place on upgrade, which would re-import translations the site has
+		// since cleared.
+		if (metadata_exists('term', $lang_id, self::PLL_STRINGS_META_KEY)) {
+			return $this->normalize_string_pairs(get_term_meta($lang_id, self::PLL_STRINGS_META_KEY, true));
+		}
+
+		$mo_post = $this->get_polylang_mo_post($lang_id);
+
+		if (!isset($mo_post->ID)) {
+			return array();
+		}
+
+		// Polylang 2.1 - 3.3 stored them in post meta on the polylang_mo post; same rule applies.
+		if (metadata_exists('post', $mo_post->ID, self::PLL_STRINGS_META_KEY)) {
+			return $this->normalize_string_pairs(get_post_meta($mo_post->ID, self::PLL_STRINGS_META_KEY, true));
+		}
+
+		// Polylang < 2.1 kept them serialised in the post content.
+		return $this->normalize_string_pairs(maybe_unserialize($mo_post->post_content));
+	}
+
+	/**
+	 * @param int $lang_id A `language` taxonomy term ID.
+	 *
+	 * @return object|null The polylang_mo post carrying this language's strings, if it exists.
+	 */
+	private function get_polylang_mo_post($lang_id) {
+		global $wpdb;
+
+		$query = "SELECT ID, post_content FROM {$wpdb->posts}
+			WHERE post_type = 'polylang_mo' AND post_title = %s
+			ORDER BY ID DESC LIMIT 1";
+
+		return $wpdb->get_row($wpdb->prepare($query, 'polylang_mo_' . $lang_id));
+	}
+
+	/**
+	 * Keeps only the well-formed entries of a Polylang string table.
+	 *
+	 * Every storage location holds the same shape — a list of array($source, $translation) — but
+	 * a partially written or hand-edited row can hold anything. Entries with an empty source are
+	 * skipped (as Polylang skips them on read), and so are entries with an empty translation: there
+	 * is nothing to hand WPML, and writing a blank translation would be worse than writing none.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return array List of array($source, $translation), both non-empty strings.
+	 */
+	private function normalize_string_pairs($value) {
+		if (!is_array($value)) {
+			return array();
+		}
+
+		$pairs = array();
+
+		foreach ($value as $pair) {
+			if (!is_array($pair) || !isset($pair[0], $pair[1])) {
+				continue;
+			}
+
+			if (!is_string($pair[0]) || !is_string($pair[1]) || '' === $pair[0] || '' === $pair[1]) {
+				continue;
+			}
+
+			$pairs[] = array($pair[0], $pair[1]);
+		}
+
+		return $pairs;
+	}
+
+	/**
+	 * Hands one language's Polylang string translations to WPML String Translation.
+	 *
+	 * `$wpml_string_translations` is indexed by `icl_strings.language`, which holds WPML language
+	 * codes. Both lookups therefore have to use the converted code, not the Polylang slug.
+	 *
+	 * @param int   $lang_id                  A `language` taxonomy term ID.
+	 * @param array $string_groups            List of array($source, $translation).
+	 * @param array $polylang_languages_map   language term_id => Polylang slug.
+	 * @param array $wpml_string_translations WPML code => string value => row.
+	 */
 	private function migrate_string_groups($lang_id, $string_groups, $polylang_languages_map, $wpml_string_translations) {
+		if (!isset($polylang_languages_map[$lang_id]) || !function_exists('icl_add_string_translation')) {
+			return;
+		}
 
-		$indexed_polylang_string_group = array();
+		$from = $this->polylang_data->lang_slug_to_wpml_format($this->polylang_data->get_default_language_slug());
+		$to = $this->polylang_data->lang_slug_to_wpml_format($polylang_languages_map[$lang_id]);
 
-		$default_language = $this->polylang_data->get_default_language_slug();
+		if ('' === $from || '' === $to || $from === $to) {
+			return;
+		}
 
-		$to_language = $polylang_languages_map[$lang_id];
+		$status = defined('ICL_STRING_TRANSLATION_COMPLETE') ? ICL_STRING_TRANSLATION_COMPLETE : 10;
 
-		$default_language_wpml_format = $this->polylang_data->lang_slug_to_wpml_format($default_language);
+		foreach ($string_groups as $group) {
+			// Polylang stores (source in the default language, translation in $to). WPML may have
+			// registered the string under either language, and occasionally under the translated
+			// value rather than the source, so try each combination in turn.
+			$candidates = array(
+				array($from, $group[0], $to, $group[1]),
+				array($to, $group[0], $from, $group[1]),
+				array($from, $group[1], $to, $group[0]),
+				array($to, $group[1], $from, $group[0]),
+			);
 
-		$to_language_wpml_format = $this->polylang_data->lang_slug_to_wpml_format($to_language);
+			foreach ($candidates as $candidate) {
+				list($registered_language, $registered_value, $target_language, $target_value) = $candidate;
 
-		foreach($string_groups as $group) {
-			if (isset($wpml_string_translations[$default_language][ $group[0] ])) {
+				if (!isset($wpml_string_translations[$registered_language][$registered_value])) {
+					continue;
+				}
+
 				icl_add_string_translation(
-					$wpml_string_translations[$default_language][$group[0]]->id,
-					$to_language_wpml_format,
-					$group[1],
-					ICL_STRING_TRANSLATION_COMPLETE
-					);
-			} else if (isset($wpml_string_translations[$to_language][ $group[0] ])) {
-					icl_add_string_translation(
-					$wpml_string_translations[$to_language][$group[0]]->id,
-					$default_language_wpml_format,
-					$group[1],
-					ICL_STRING_TRANSLATION_COMPLETE
-					);
-			} else if (isset($wpml_string_translations[$default_language][ $group[1] ])) {
-				icl_add_string_translation(
-					$wpml_string_translations[$default_language][$group[1]]->id,
-					$to_language_wpml_format,
-					$group[0],
-					ICL_STRING_TRANSLATION_COMPLETE
-					);
-			} else if (isset($wpml_string_translations[$to_language][ $group[1] ])) {
-					icl_add_string_translation(
-					$wpml_string_translations[$to_language][$group[1]]->id,
-					$default_language_wpml_format,
-					$group[0],
-					ICL_STRING_TRANSLATION_COMPLETE
-					);
+					$wpml_string_translations[$registered_language][$registered_value]->id,
+					$target_language,
+					$target_value,
+					$status
+				);
+
+				break;
 			}
 		}
 	}

--- a/tests/test-string-storage-regression.php
+++ b/tests/test-string-storage-regression.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Regression test for the string-translation reader's storage precedence.
+ *
+ * Polylang leaves the old string stores in place when it upgrades them, so a site that has
+ * *cleared* its string translations still carries stale copies in the older locations. The
+ * reader must therefore treat a newest store that exists but is empty as authoritative, and
+ * never fall through to re-import those stale copies.
+ *
+ * Self-contained on purpose: it runs with plain `php` and no WordPress, database or Composer,
+ * so it can be executed before any test infrastructure exists. Exit code 0 = pass, 1 = fail.
+ *
+ * Run: php tests/test-string-storage-regression.php
+ */
+
+error_reporting(E_ALL);
+
+define('ABSPATH', __DIR__ . '/');
+
+// --- Minimal WordPress/WPML stubs: just enough to load the plugin and drive migrate_strings().
+
+$GLOBALS['options']     = array();
+$GLOBALS['term_meta']   = array();  // term_id => meta_key => value
+$GLOBALS['post_meta']   = array();  // post_id => meta_key => value
+$GLOBALS['mo_posts']    = array();  // lang term_id => (object) ID, post_content
+$GLOBALS['icl_strings'] = array();  // list of (object) id, language, value
+$GLOBALS['st_calls']    = array();  // every icl_add_string_translation() call
+$GLOBALS['languages']   = array();  // `language` taxonomy terms as Polylang stores them
+
+if (!defined('ICL_STRING_TRANSLATION_COMPLETE')) {
+	define('ICL_STRING_TRANSLATION_COMPLETE', 10);
+}
+
+function add_action($hook, $cb = null, $p = 10, $a = 1) {}
+function add_filter($hook, $cb = null, $p = 10, $a = 1) {}
+function apply_filters($tag, $value) { return $value; }
+function do_action($tag, $args = null) {}
+function register_taxonomy($tax, $object_type = null, $args = array()) {}
+function is_admin() { return true; }
+function __($text, $domain = null) { return $text; }
+
+function get_option($name, $default = false) {
+	return array_key_exists($name, $GLOBALS['options']) ? $GLOBALS['options'][$name] : $default;
+}
+
+// Presence is checked with array_key_exists on purpose: an empty-but-present store must read
+// as existing, which is exactly what metadata_exists() guarantees in WordPress.
+function metadata_exists($meta_type, $object_id, $meta_key) {
+	$store = isset($GLOBALS[$meta_type . '_meta']) ? $GLOBALS[$meta_type . '_meta'] : array();
+	return isset($store[$object_id]) && array_key_exists($meta_key, $store[$object_id]);
+}
+
+function get_term_meta($id, $key, $single = false) {
+	return $GLOBALS['term_meta'][$id][$key] ?? ($single ? '' : array());
+}
+
+function get_post_meta($id, $key, $single = false) {
+	return $GLOBALS['post_meta'][$id][$key] ?? ($single ? '' : array());
+}
+
+function is_serialized($data) {
+	if (!is_string($data)) { return false; }
+	$data = trim($data);
+	if (strlen($data) < 4 || ':' !== $data[1]) { return false; }
+	return (bool) preg_match('/^[aOsibdN]:/', $data);
+}
+
+function maybe_unserialize($value) {
+	if (is_serialized($value)) { return @unserialize(trim($value)); }
+	return $value;
+}
+
+function icl_add_string_translation($string_id, $language, $value = null, $status = false) {
+	$GLOBALS['st_calls'][] = compact('string_id', 'language', 'value', 'status');
+	return count($GLOBALS['st_calls']);
+}
+
+function get_terms($args) {
+	$taxonomy = is_array($args) && isset($args['taxonomy']) ? $args['taxonomy'] : $args;
+	return 'language' === $taxonomy ? $GLOBALS['languages'] : array();
+}
+
+class Regression_WPDB {
+	public $prefix = 'wp_';
+	public $posts  = 'wp_posts';
+
+	public function delete($table, $where) { return 1; }
+
+	public function prepare($query, ...$args) {
+		return vsprintf(str_replace(array('%d', '%s'), '%s', $query), $args);
+	}
+
+	// Resolves the polylang_mo post lookup from get_polylang_mo_post().
+	public function get_row($query) {
+		if (preg_match('/post_title\s*=\s*polylang_mo_(\d+)/', $query, $m)) {
+			return $GLOBALS['mo_posts'][(int) $m[1]] ?? null;
+		}
+		return null;
+	}
+
+	public function get_results($query) {
+		if (false !== strpos($query, 'icl_strings')) { return $GLOBALS['icl_strings']; }
+		return array();
+	}
+}
+
+$GLOBALS['wpdb'] = new Regression_WPDB();
+
+// --- Load the plugin.
+
+require dirname(__DIR__) . '/migrate-polylang-to-wpml.php';
+
+/**
+ * Runs one migration against the given storage setup and returns the WPML String Translation
+ * calls the plugin made.
+ */
+function run_scenario($name, $setup) {
+	$GLOBALS['options']     = array('polylang' => array('default_lang' => 'es'));
+	$GLOBALS['term_meta']   = $setup['term_meta'] ?? array();
+	$GLOBALS['post_meta']   = $setup['post_meta'] ?? array();
+	$GLOBALS['mo_posts']    = $setup['mo_posts'] ?? array();
+	$GLOBALS['icl_strings'] = $setup['icl_strings'] ?? array();
+	$GLOBALS['st_calls']    = array();
+
+	$es_term = (object) array(
+		'term_id' => 2,
+		'term_taxonomy_id' => 2,
+		'slug' => 'es',
+		'name' => 'Espanol',
+		'description' => serialize(array('locale' => 'es_ES', 'rtl' => 0, 'flag_code' => 'es')),
+	);
+	$en_term = (object) array(
+		'term_id' => 5,
+		'term_taxonomy_id' => 5,
+		'slug' => 'en',
+		'name' => 'English',
+		'description' => serialize(array('locale' => 'en_US', 'rtl' => 0, 'flag_code' => 'us')),
+	);
+	$GLOBALS['languages'] = array($es_term, $en_term);
+
+	// Reset the terms cache mpw_polylang_data keeps between requests.
+	$terms_cache = new ReflectionProperty('mpw_polylang_data', 'terms');
+	$terms_cache->setAccessible(true);
+	$terms_cache->setValue(null, null);
+
+	$plugin  = new Migrate_Polylang_To_WPML();
+	$strings = new ReflectionMethod('Migrate_Polylang_To_WPML', 'migrate_strings');
+	$strings->setAccessible(true);
+	$strings->invoke($plugin);
+
+	echo "\n=== $name ===\n";
+	foreach ($GLOBALS['st_calls'] as $call) {
+		printf("  string_id=%-4s -> lang=%-8s value=%s\n", $call['string_id'], $call['language'], var_export($call['value'], true));
+	}
+	if (!$GLOBALS['st_calls']) {
+		echo "  (no strings migrated)\n";
+	}
+
+	return $GLOBALS['st_calls'];
+}
+
+$failures = 0;
+function check($label, $condition) {
+	global $failures;
+	if ($condition) {
+		echo "  PASS  $label\n";
+	} else {
+		echo "  FAIL  $label\n";
+		$failures++;
+	}
+}
+
+$pairs = array(
+	array('Buscar', 'Search'),
+	array('Comentarios', 'Comments'),
+);
+
+// WPML registers the source strings under the site's default language ("es").
+$registry = array(
+	(object) array('id' => 11, 'language' => 'es', 'value' => 'Buscar'),
+	(object) array('id' => 12, 'language' => 'es', 'value' => 'Comentarios'),
+);
+
+// Positive control — populated modern storage migrates normally.
+$calls = run_scenario('Populated term meta migrates into WPML ST', array(
+	'term_meta'   => array(5 => array('_pll_strings_translations' => $pairs)),
+	'icl_strings' => $registry,
+));
+check('both pairs migrated to the en code', 2 === count($calls)
+	&& 'en' === $calls[0]['language'] && 'Search' === $calls[0]['value']
+	&& 'Comments' === $calls[1]['value']);
+
+// The regression: the site cleared its translations, so the >= 3.4 term meta exists but is
+// empty while the pre-2.1 polylang_mo content still holds the stale copies Polylang kept for
+// rollback. The empty-but-present newest store wins; nothing may be imported.
+$calls = run_scenario('Cleared translations do not fall back to stale copies', array(
+	'term_meta'   => array(5 => array('_pll_strings_translations' => array())),
+	'mo_posts'    => array(5 => (object) array('ID' => 900, 'post_content' => serialize($pairs))),
+	'icl_strings' => $registry,
+));
+check('an empty term-meta store is authoritative: the stale copies are not imported', array() === $calls);
+
+echo "\n" . ($failures ? "$failures CHECK(S) FAILED\n" : "ALL CHECKS PASSED\n");
+exit($failures ? 1 : 0);


### PR DESCRIPTION
**Summary.** Reads string translations from where Polylang actually stores them (term meta since 3.4), restoring a feature that has silently done nothing since 2017.

**Problem.** Polylang moved string storage twice: to post meta in 2.1, to `language`-term meta in 3.4. This plugin still read `post_content`, which Polylang stopped writing in **2.1 (2017)** — so string migration returned nothing on every release since, while the handler still reported *"String translations have been migrated"*. A second bug: `migrate_string_groups()` indexes WPML's registry by `icl_strings.language` (WPML codes) but looked it up with Polylang slugs, so pt/zh failed even on 1.x.

**Change.** New `get_polylang_language_strings()` reads term meta → post meta → `post_content`, newest first (Polylang leaves the old copies for rollback, so newest wins). `normalize_string_pairs()` keeps only well-formed pairs. `migrate_string_groups()` converts both languages to WPML codes and collapses the four copy-pasted branches into one loop with a `break` (the original `else if` chain already stopped at the first match; the loop just removes the duplication).

**Risk.** Low-to-moderate — mostly "start finding data that was invisible." A re-run sends WPML ST a batch of calls it did not get before. Only strings already registered in `icl_strings` can be translated; unmatched ones are skipped (counted later).

**Verified.** Six scenarios (one per storage generation, all-three-populated, Portuguese, malformed): new code 9/9, original 8/9 fail — the one it passes is the pre-2.1 `post_content` path it was written for. Signatures from WPML ST 3.4.0 & 3.5.3. **Now verified end-to-end on a real modern install** (Polylang Pro 3.8.5, WPML ST 3.5.3): with strings in the modern `_pll_strings_translations` term meta *and a decoy planted in the old `polylang_mo` post*, the reader returned the **term-meta** pairs and never the decoy — proving newest-first precedence on real storage — and the migration **wrote them into WPML String Translation**: `{languages:3, translated:7, unmatched:1}`, landing in `icl_string_translations` including `pt-pt` (Hello→Ola, Read more→Ler mais), with zero decoy values written. (The one `unmatched` is the documented case: a string WPML hasn't registered can't be matched.)