### PR TITLE
Make Polylang data getters read-only and move the translation cleanup into an explicit step

### DIFF
--- a/classes/class-mpw_polylang_data.php
+++ b/classes/class-mpw_polylang_data.php
@@ -33,11 +33,8 @@ class mpw_polylang_data {
 	private function get_terms($tax) {
 
 		if (!isset(self::$terms[$tax])) {
-			global $wpdb;
 
 			register_taxonomy($tax, null);
-			$table = $wpdb->prefix . "icl_translations";
-			$wpdb->delete($table, array('element_type' => 'tax_'.$tax));
 
 			// The two-argument form of get_terms() has been deprecated since WordPress 4.5.
 			$terms = get_terms(array(
@@ -51,6 +48,30 @@ class mpw_polylang_data {
 		}
 
 		return self::$terms[$tax];
+	}
+
+	/**
+	 * Delete WPML translation-relation rows for one of Polylang's private
+	 * taxonomies, so a (re-)run of the migration starts from a clean state.
+	 *
+	 * This cleanup used to run inside get_terms() as a side effect of reading
+	 * Polylang data. The getters are now pure reads, and the cleanup is an
+	 * explicit step that the migration handlers call before they read. The
+	 * method also checks manage_options itself so it only ever runs for an
+	 * administrator.
+	 *
+	 * @param string $tax Polylang taxonomy, e.g. 'language', 'post_translations'.
+	 *
+	 * @return void
+	 */
+	public function reset_translations($tax) {
+		if (!current_user_can('manage_options')) {
+			return;
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . "icl_translations";
+		$wpdb->delete($table, array('element_type' => 'tax_' . $tax));
 	}
 	
 	public function get_additional_languages_names() {

--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -358,6 +358,10 @@ $text = "
 		$this->verify_ajax_request();
 
 		if ($this->pre_check_ready_all()) {
+			// Clear stale WPML relation rows before the posts migration reads the
+			// Polylang data below. This used to happen inside the getters.
+			$this->polylang_data->reset_translations('post_translations');
+			$this->polylang_data->reset_translations('language');
 			require_once 'classes/class-mpw_migrate_posts.php';
 			$mpw_migrate_posts = new mpw_migrate_posts($this->polylang_data);
 			$mpw_migrate_posts->migrate_posts();
@@ -433,6 +437,10 @@ $text = "
 	private function migrate_languages() {
 		global $wpdb;
 
+		// Clear stale WPML language-relation rows before reading the Polylang
+		// languages. This used to happen inside get_languages().
+		$this->polylang_data->reset_translations('language');
+
 		$pll_languages = $this->polylang_data->get_languages();
 
 		if (!empty($pll_languages) && is_array($pll_languages)) {
@@ -457,6 +465,10 @@ $text = "
 	 * Mixing the two is what made this method skip Portuguese and Chinese groups entirely.
 	 */
 	private function migrate_taxonomies() {
+		// Clear stale WPML term-relation rows before reading the Polylang
+		// term translations. This used to happen inside get_term_translations().
+		$this->polylang_data->reset_translations('term_translations');
+
 		$pll_term_translations = $this->polylang_data->get_term_translations();
 
 		if (empty($pll_term_translations) || !is_array($pll_term_translations)) {
@@ -587,6 +599,10 @@ $text = "
 	}
 
 	private function migrate_strings() {
+		// Clear stale WPML language-relation rows before get_languages_map()
+		// reads the Polylang languages. This used to happen inside get_languages().
+		$this->polylang_data->reset_translations('language');
+
 		$polylang_languages_map = $this->polylang_data->get_languages_map();
 
 		$wpml_string_translations = $this->get_wpml_string_translations();

--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -465,9 +465,10 @@ $text = "
 	 * Mixing the two is what made this method skip Portuguese and Chinese groups entirely.
 	 */
 	private function migrate_taxonomies() {
-		// Clear stale WPML term-relation rows before reading the Polylang
-		// term translations. This used to happen inside get_term_translations().
+		// Clear stale WPML relation rows before reading the Polylang term
+		// translations and languages. This used to happen inside the getters.
 		$this->polylang_data->reset_translations('term_translations');
+		$this->polylang_data->reset_translations('language');
 
 		$pll_term_translations = $this->polylang_data->get_term_translations();
 
@@ -710,6 +711,10 @@ $text = "
 
 	private function migrate_widgets() {
 		global $wpdb;
+
+		// Clear stale WPML language-relation rows before lang_slug_to_wpml_format()
+		// reads the Polylang languages. This used to happen inside get_languages().
+		$this->polylang_data->reset_translations('language');
 
 		$options_table = $wpdb->prefix . "options";
 

--- a/tests/phpunit/TestPolylangData.php
+++ b/tests/phpunit/TestPolylangData.php
@@ -1,0 +1,86 @@
+<?php
+
+require_once ABSPATH . 'classes/class-mpw_polylang_data.php';
+
+/**
+ * Covers mpw_polylang_data: the getters are pure reads and must not modify
+ * icl_translations; the cleanup lives in reset_translations(), which only runs
+ * for a user with manage_options.
+ */
+class TestPolylangData extends OTGS_TestCase {
+
+	/** @var PolylangDataWpdb */
+	private $wpdb;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Reset the getter's static per-taxonomy cache between tests.
+		$prop = new ReflectionProperty( 'mpw_polylang_data', 'terms' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, null );
+
+		$this->wpdb = new PolylangDataWpdb();
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- The subject under test reads the global $wpdb; swapping in the recording double is the point of the test.
+		$GLOBALS['wpdb'] = $this->wpdb;
+	}
+
+	public function tearDown(): void {
+		unset( $GLOBALS['wpdb'] );
+		parent::tearDown();
+	}
+
+	public function test_get_languages_reads_without_deleting_translations() {
+		WP_Mock::userFunction( 'register_taxonomy', array( 'return' => true ) );
+		WP_Mock::userFunction(
+			'get_terms',
+			array(
+				'return' => array(
+					(object) array(
+						'slug'    => 'fr',
+						'name'    => 'French',
+						'term_id' => 7,
+					),
+				),
+			)
+		);
+
+		$subject = new mpw_polylang_data();
+		$result  = $subject->get_languages();
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( array(), $this->wpdb->deletes, 'a getter must not modify icl_translations' );
+	}
+
+	public function test_reset_translations_deletes_for_an_authorized_admin() {
+		WP_Mock::userFunction(
+			'current_user_can',
+			array(
+				'args'   => array( 'manage_options' ),
+				'return' => true,
+			)
+		);
+
+		$subject = new mpw_polylang_data();
+		$subject->reset_translations( 'language' );
+
+		$this->assertCount( 1, $this->wpdb->deletes );
+		$this->assertSame( 'wp_icl_translations', $this->wpdb->deletes[0]['table'] );
+		$this->assertSame( array( 'element_type' => 'tax_language' ), $this->wpdb->deletes[0]['where'] );
+	}
+
+	public function test_reset_translations_is_a_no_op_without_manage_options() {
+		WP_Mock::userFunction(
+			'current_user_can',
+			array(
+				'args'   => array( 'manage_options' ),
+				'return' => false,
+			)
+		);
+
+		$subject = new mpw_polylang_data();
+		$subject->reset_translations( 'language' );
+
+		$this->assertSame( array(), $this->wpdb->deletes, 'reset_translations() must do nothing without manage_options' );
+	}
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -5,4 +5,5 @@ define( 'ABSPATH', dirname( __DIR__, 2 ) . '/' );
 require_once ABSPATH . 'vendor/autoload.php';
 require_once ABSPATH . 'vendor/otgs/unit-tests-framework/phpunit/bootstrap.php';
 require_once __DIR__ . '/includes/class-string-storage-wpdb.php';
+require_once __DIR__ . '/includes/class-polylang-data-wpdb.php';
 require_once ABSPATH . 'classes/class-mpw_polylang_string_storage.php';

--- a/tests/phpunit/includes/class-polylang-data-wpdb.php
+++ b/tests/phpunit/includes/class-polylang-data-wpdb.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Recording $wpdb double: captures delete() calls so tests can assert whether
+ * the icl_translations cleanup ran.
+ */
+class PolylangDataWpdb {
+
+	public string $prefix = 'wp_';
+	public array $deletes = array();
+
+	public function delete( string $table, array $where ): int {
+		$this->deletes[] = array(
+			'table' => $table,
+			'where' => $where,
+		);
+
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary

The Polylang data getters cleared WPML translation-relation rows as a side effect of reading Polylang data. This change separates reading from cleanup.

## Changes

- `get_languages()`, `get_post_translations()` and `get_term_translations()` now only read.
- A new `reset_translations()` method performs the cleanup. The migration handlers call it before they read, and it checks `manage_options` itself.
- Adds `TestPolylangData` covering the read-only getters and the capability check, with a recording wpdb double in `tests/phpunit/includes`.

## Testing

- `composer test`, `composer phpcs` and `composer phpstan` pass locally.
- The "PHP quality" CI workflow passed on the branch.