### PR TITLE
[wpmlbridge-384] Set the version to 5.0.0

### DIFF
--- a/migrate-polylang-to-wpml.php
+++ b/migrate-polylang-to-wpml.php
@@ -6,7 +6,7 @@ Description: Import multilingual data from Polylang to WPML | <a href="https://w
 Author: OnTheGoSystems
 Author URI: http://www.onthegosystems.com/
 Plugin uri: https://wpml.org
-Version: 1.0
+Version: 5.0.0
  */
 
 defined('ABSPATH') || exit;


### PR DESCRIPTION
WPML aligns every component on the same MAJOR version and on the `MAJOR.MINOR.HOTFIX` format ([ma-10138](https://onthegosystems.myjetbrains.com/youtrack/issue/ma-10138)).

Same change the 14 GitLab glue plugins already merged. The release branch `release/5.0` and the tag `5.0.0-rc.1` are pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181WRtEEERD3Br6GkzYDfag